### PR TITLE
Fixes missing `project.json` expected by `npm` during the installation procedure.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.nova

--- a/.nova/Configuration.json
+++ b/.nova/Configuration.json
@@ -1,3 +1,5 @@
 {
-  "workspace.color" : 1
+  "editor.default_syntax" : "javascript",
+  "workspace.art_style" : 1,
+  "workspace.color" : 8
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,24 @@
 ## [Upcoming]
 - Add language server configuration settings.
 
+## [0.1.8] - 2022-04-22
+### Changed
+- During the first installation, a `package.json` file will be generated from scratch, in
+  order to allow `npm` to do an installation in the correct place.
+### Fixed
+- Some path names were inconsistent.
+### Updated
+- [README.md](README.md) includes some information about the caveats of the automatic
+  installation process for Inteliphense using `npm`.
+
 ## [0.1.7] - 2022-04-21
 ### Removed
 - outdated Known Issues from README.
 
 ## [0.1.6] - 2022-04-21
-  ### Updated
-  - intelephense version to 1.8.2. This resolved the initialization errors and now
-    also provides PHP 8 support.
+### Updated
+- intelephense version to 1.8.2. This resolved the initialization errors and now
+  also provides PHP 8 support.
 
 ## [0.1.5] - 2021-04-26
 ### Reverted

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 
-Copyright © 2021 GeneaLabs, Mike Bronner.
+Copyright © 2021,2022 GeneaLabs, Mike Bronner.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ During activation, this extension will attempt to deploy on the workspace a full
 
 In some circumstances (under investigation!), `npm` may fail to create the directories it needs (notably, `node_modules`) in the place where Nova (and, later, Intelephense) expects them; as a consequence, the LSP will fail with a console error that might not be easy to debug — since it depends quite a lot on how you are currently managing `npm`, both at the global as well as the local level.
 
-This step may require some improvement in the future; alternatively, there might be a choice to use the _global_ installation of `npm` instead, or, if you have one local `npm` installation in your current PHP project, this extension might attempt to use it. Such options will require further options on the Preferences panel; stay tuned...
+This step may require some improvement in the future; alternatively, there might be a choice to use the _global_ installation of `npm` instead, or, if you have one local `npm` installation in your current PHP project, this extension might attempt to use it. Such options will require a few new options on the Preferences panel; stay tuned...
 
 <!--
 👋 That's it! Happy developing!

--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ To configure global preferences, open **Extensions → Extension Library...** th
 
 You can also configure preferences on a per-project basis in **Project → Project Settings...**
 
+## Caveats
+
+During activation, this extension will attempt to deploy on the workspace a fully functional (and independently managed) installation of Intelephense; you will need to have `npm` installed (you can get it with `brew install npm`).
+
+In some circumstances (under investigation!), `npm` may fail to create the directories it needs (notably, `node_modules`) in the place where Nova (and, later, Intelephense) expects them; as a consequence, the LSP will fail with a console error that might not be easy to debug — since it depends quite a lot on how you are currently managing `npm`, both at the global as well as the local level.
+
+This step may require some improvement in the future; alternatively, there might be a choice to use the _global_ installation of `npm` instead, or, if you have one local `npm` installation in your current PHP project, this extension might attempt to use it. Such options will require further options on the Preferences panel; stay tuned...
+
 <!--
 👋 That's it! Happy developing!
 

--- a/Scripts/main.js
+++ b/Scripts/main.js
@@ -1,23 +1,28 @@
 var workspaceStoragePath = nova.path.join(nova.extension.workspaceStoragePath, "intelephense");
 var globalStoragePath = nova.path.join(nova.extension.globalStoragePath, "intelephense");
 var langserver = null;
-var requiredVersion = "1.8.2";
+var requiredVersion = "1.8.2";  // for Inteliphense
+var packageJSONfile = nova.path.join(workspaceStoragePath, "package.json"); // Create it if it doesn't exist, or npm will silently fail (gwyneth 20220422)
+
 var install = async function () {
+    if (nova.config.get('genealabs.intelephense.debugging', 'boolean')) {
+        console.log("install: Launching 'npm' in directory:", workspaceStoragePath);
+    }
     installation = new Process(
         "/usr/bin/env",
         {
             args: ["npm", "install", "intelephense@" + requiredVersion],
-            cwd: nova.extension.workspaceStoragePath,
+            cwd: /* nova.extension.workspaceStoragePath */ workspaceStoragePath,
         }
     );
     installation.onStdout(function (output) {
         if (nova.config.get('genealabs.intelephense.debugging', 'boolean')) {
-            console.log("Installation Output", output.trim());
+            console.log("Installation Output:", output.trim());
         }
     });
     installation.onDidExit(function (status) {
         if (nova.config.get('genealabs.intelephense.debugging', 'boolean')) {
-            console.log("Installation completed with status", status);
+            console.log("Installation completed with status:", status);
         }
 
         langserver = new IntelephenseLanguageServer();
@@ -30,19 +35,61 @@ var install = async function () {
     installation.start();
 };
 var installIfMissing = async function () {
+    /* check first if we have a valid `package.json` file in the right place */
+    if (nova.fs.access(packageJSONfile, nova.fs.F_OK) === false) {
+        if (nova.config.get('genealabs.intelephense.debugging', 'boolean')) {
+            console.log("installIfMissing: 'package.json' not found, creating a default one.");
+        }
+        /*  Now create our own `package.json` from scratch, using the defaults below.
+         *  Note: I'm pretty sure there must be a more idiomatic JS way to do this;
+         *  also: nothing is done concurrently, since this whole function is already async anyway.
+         *  (gwyneth 20220422)
+         */
+        fileContent = `{
+          "name": "` + nova.extension.name + `",
+          "description": "` + nova.extension.description + `",
+          "version": "` + nova.extension.version + `",
+          "repository": {
+            "type": "git",
+            "url": "https://github.com/GeneaLabs/panic-nova-intelephense"
+          },
+          "keywords": ["languages"],
+          "author": "` + nova.extension.vendor + `",
+          "license": "MIT",
+          "bugs": {
+            "url": "https://github.com/GeneaLabs/panic-nova-intelephense/issues"
+          },
+          "homepage": "https://extensions.panic.com/extensions/genealabs/genealabs.intelephense/"
+        }`;
+        try {
+            let fileJSON = nova.fs.open(packageJSONfile, 'wt');
+            fileJSON.write(fileContent);
+            fileJSON.close();
+        } catch(error) {
+            console.warn("installIfMissing: could not create 'package.json' file, error was: ", error);
+        }
+    } else  {
+        if (nova.config.get('genealabs.intelephense.debugging', 'boolean')) {
+            console.log("installIfMissing: readable 'package.json' found, continuing install with 'npm'...");
+        }
+    }
+
     let installedVersion = "";
+    if (nova.config.get('genealabs.intelephense.debugging', 'boolean')) {
+        console.log("installIfMissing: Launching npm in path:", workspaceStoragePath);
+    }
     let process = new Process(
         "/usr/bin/env",
         {
             args: ["npm", "list", "--depth 0", "--parseable", "--long", "intelephense"],
-            cwd: nova.extension.workspaceStoragePath,
+            cwd: /* nova.extension.workspaceStoragePath */ workspaceStoragePath,
         }
     );
     process.onStdout(function (output) {
         installedVersion = ((output.split(":")[1] || "").split("@")[1] || "");
 
         if (nova.config.get('genealabs.intelephense.debugging', 'boolean')) {
-            console.log("Currenlty installed version", installedVersion);
+            console.log("installIfMissing: Intelephense currently installed version:", installedVersion);
         }
     })
     process.onDidExit(function (status) {
@@ -51,7 +98,9 @@ var installIfMissing = async function () {
 
             return;
         }
-
+        if (nova.config.get('genealabs.intelephense.debugging', 'boolean')) {
+            console.log("installIfMissing: Checking installation did complete with status:", status);
+        }
         langserver = new IntelephenseLanguageServer();
     });
     process.start();
@@ -74,7 +123,7 @@ var activate = async function () {
         nova.fs.mkdir(workspaceStoragePath);
         nova.fs.mkdir(globalStoragePath);
     } catch (error) {
-        console.error("Directory creation failed:", error);
+        console.error("Directory creation failed during activation:", error);
     }
 
     await installIfMissing();
@@ -109,6 +158,12 @@ class IntelephenseLanguageServer {
         this.start();
     }
 
+    activate() {
+        if (nova.config.get('genealabs.intelephense.debugging', 'boolean')) {
+            console.log("Activating language server using:", workspaceStoragePath);
+        }
+    }
+
     deactivate() {
         if (nova.config.get('genealabs.intelephense.debugging', 'boolean')) {
             console.log("Deactivating language server.");
@@ -124,12 +179,12 @@ class IntelephenseLanguageServer {
         }
 
         if (nova.config.get('genealabs.intelephense.debugging', 'boolean')) {
-            console.log("Starting language server.");
+            console.log("Starting language server with path:", workspaceStoragePath);
         }
 
         if (!path) {
             path = nova.path.join(
-                nova.extension.workspaceStoragePath,
+                workspaceStoragePath,
                 'node_modules',
                 'intelephense',
                 'lib',

--- a/extension.json
+++ b/extension.json
@@ -3,7 +3,7 @@
     "name": "Intelephense",
     "organization": "GeneaLabs",
     "description": "Nova wrapper of the fabulous Intelephense language server from Ben Mewburn.",
-    "version": "0.1.7",
+    "version": "0.1.8",
     "categories": ["languages"],
 
     "main": "main.js",


### PR DESCRIPTION
## Fixes:
### Changed
- During the first installation, a `package.json` file will be generated from scratch, in
  order to allow `npm` to do an installation in the correct place.
### Fixed
- Some path names were inconsistent.
### Updated
- [README.md](README.md) includes some information about the caveats of the automatic
  installation process for Inteliphense using `npm`.

(and all the above was added to the [change log](CHANGELOG.md) as well :-) )

Closes #1.

